### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Scheduler.nuspec
+++ b/MakoIoT.Device.Services.Scheduler.nuspec
@@ -21,7 +21,7 @@
       <dependency id="nanoFramework.Logging" version="1.1.76" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.Scheduler/MakoIoT.Device.Services.Scheduler.nfproj
+++ b/src/MakoIoT.Device.Services.Scheduler/MakoIoT.Device.Services.Scheduler.nfproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.41.25178\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.42.48151\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.Scheduler/packages.config
+++ b/src/MakoIoT.Device.Services.Scheduler/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.76" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.41.25178 to 1.0.42.48151</br>
[version update]

### :warning: This is an automated update. :warning:
