### PR TITLE
Update 5 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Scheduler.nuspec
+++ b/MakoIoT.Device.Services.Scheduler.nuspec
@@ -17,10 +17,10 @@
     <description>Task scheduler for MAKO-IoT. Executes given logic at defined intervals.</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot scheduler</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.59" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.25" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.62" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.29" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.52.50912" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.Scheduler/MakoIoT.Device.Services.Scheduler.nfproj
+++ b/src/MakoIoT.Device.Services.Scheduler/MakoIoT.Device.Services.Scheduler.nfproj
@@ -27,19 +27,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.52.50912\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.29\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.59\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.62\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.16.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.Services.Scheduler/packages.config
+++ b/src/MakoIoT.Device.Services.Scheduler/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.52.50912" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.50.35966 to 1.0.52.50912</br>Bumps nanoFramework.CoreLibrary from 1.16.11 to 1.17.1</br>Bumps nanoFramework.DependencyInjection from 1.1.25 to 1.1.29</br>Bumps nanoFramework.System.Collections from 1.5.59 to 1.5.62</br>Bumps nanoFramework.System.Text from 1.3.16 to 1.3.29</br>
[version update]

### :warning: This is an automated update. :warning:
